### PR TITLE
Replace return statements with core.setOutput in repo label workflow

### DIFF
--- a/.github/workflows/configure-repository-labels.yaml
+++ b/.github/workflows/configure-repository-labels.yaml
@@ -33,7 +33,7 @@ jobs:
             > Command \'/configure-default-labels\' acknowledged. Adding the labels.`
             })
             console.log('Command acknowledged')
-            core.setOutput('commentId', ackComment.data.id)
+            core.setOutput('comment_id', ackComment.data.id)
       - name: Check for missing labels
         if: steps.filter.outputs.isConfigureCommand == 'true'
         id: check_labels

--- a/.github/workflows/configure-repository-labels.yaml
+++ b/.github/workflows/configure-repository-labels.yaml
@@ -33,7 +33,7 @@ jobs:
             > Command \'/configure-default-labels\' acknowledged. Adding the labels.`
             })
             console.log('Command acknowledged')
-            return { comment_id: ackComment.data.id }
+            core.setOutput('commentId', ackComment.data.id)
       - name: Check for missing labels
         if: steps.filter.outputs.isConfigureCommand == 'true'
         id: check_labels
@@ -48,7 +48,7 @@ jobs:
             })
             const existingLabels = labels.map(label => label.name)
             const missingLabels = requiredLabels.filter(label => !existingLabels.includes(label))
-            return { missingLabels: missingLabels.join(', ') }
+            core.setOutput('missingLabels', missingLabels.join(', '))
       - name: Update acknowledgement comment with label details
         if: steps.filter.outputs.isConfigureCommand == 'true'
         id: update_ack_details


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced our automated workflow for repository label management to ensure more consistent and reliable configuration.
  - Improved the internal handling of label-related information, resulting in smoother operations and more dependable repository maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Close #56